### PR TITLE
Support multiple audiences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ Build
 .release
 .release-tmp-*/
 out/
+
+# IDEA
+.idea

--- a/src/index.js
+++ b/src/index.js
@@ -84,7 +84,11 @@ IdTokenVerifier.prototype.verify = function (token, nonce, cb) {
     return cb(new error.TokenValidationError('Issuer ' + iss + ' is not valid.'), false);
   }
 
-  if (this.audience !== aud) {
+  if (Array.isArray(aud)) {
+    if (!aud.includes(this.audience)) {
+      return cb(new error.TokenValidationError('Audience ' + aud + ' is not valid.'), false);
+    }
+  } else if (this.audience !== aud) {
     return cb(new error.TokenValidationError('Audience ' + aud + ' is not valid.'), false);
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -84,7 +84,9 @@ IdTokenVerifier.prototype.verify = function (token, nonce, cb) {
     return cb(new error.TokenValidationError('Issuer ' + iss + ' is not valid.'), false);
   }
 
-  if (this.audience !== aud) {
+  if (Array.isArray(aud) && !aud.includes(this.audience)) {
+    return cb(new error.TokenValidationError('Audience ' + aud + ' is not valid.'), false);
+  } else if (this.audience !== aud) {
     return cb(new error.TokenValidationError('Audience ' + aud + ' is not valid.'), false);
   }
 

--- a/test/token-verification.test.js
+++ b/test/token-verification.test.js
@@ -138,6 +138,19 @@ describe('jwt-verification', function () {
     );
   });
 
+  it('should allow multiple audiences in the token', function (done) {
+    helpers.assertTokenValidationError(
+      {
+        issuer: 'https://wptest.auth0.com/',
+        audience: 'gYSNlU4YC4V1YPdqq8zPQcup6rJw1Mbt',
+      },
+      ['gYSNlU4YC4V1YPdqq8zPQcup6rJw1Mbt'],
+      'Nonce does not match.',
+      null,
+      done
+    );
+  });
+
   it('should check the token expiration', function (done) {
     helpers.assertTokenValidationError(
       {


### PR DESCRIPTION
Auth tokens can be issued for multiple audiences. This PR allows for an array of strings to exist in aud. The token will be considered valid if the requested audience exists in the JWT's aud array.

Still supports a single string in aud as well.